### PR TITLE
Removes console.log of response

### DIFF
--- a/bullet-train-core.js
+++ b/bullet-train-core.js
@@ -8,7 +8,6 @@ const BulletTrain = class {
 
         this.getJSON = function (url, method) {
             const { environmentID } = this;
-            console.log(url);
             return fetch(url + '?format=json', {
                 method: method || 'GET',
                 headers: {


### PR DESCRIPTION
Logging out the flags to the console is a security hole. We don't want to push that information into various logging apps. 