### PR TITLE
Make bullet-train flags stateless, fix binding.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bullet-train-nodejs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Bullet Train lets you manage features flags and remote config across web, mobile and server side applications. Deliver true Continuous Integration. Get builds out faster. Control who has access to new features.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
1 - we were using a singleton collection of flags, which get updated after every request to the API. This is pretty bad as it introduces a possible race condition where user a gets user b's flags
2 - we were using some weird patterns to support binding this/self
3 - we were only returning remote configs if enabled was true, pretty certain we removed that field a while back