### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const config = require("./config");
-const fetch = require('node-fetch');
+const fetch = require('node-fetch').default;
 const bt = require('./bullet-train-core');
 const bulletTrain = bt({fetch: fetch});
 


### PR DESCRIPTION
My build uses Webpack and fails with `TypeError: fetch is not a function`.
Webpack and `node-fetch 2.1.2` (in use here) will not use the CommonJS solution by default.

Explanations in this thread:
https://github.com/bitinn/node-fetch/issues/450#issuecomment-387045223